### PR TITLE
Handle base images without /usr/share/X11/xorg.conf.d such as DietPi

### DIFF
--- a/oneshot.sh
+++ b/oneshot.sh
@@ -264,9 +264,11 @@ if [ "$BOARD_bootLoader" -eq 1 ]; then
 	dd if="$boot_loader_file" of=/dev/"$target_disk" bs=512 seek=$BOARD_bootSector
 fi
 
-if [ -d /usr/share/X11/xorg.conf.d ]; then
-	cp $SRC_DIR/apps/xorg/10-*.conf /usr/share/X11/xorg.conf.d
+if [ ! -d /usr/share/X11/xorg.conf.d ]; then
+	mkdir -p /usr/share/X11/xorg.conf.d
 fi
+cp $SRC_DIR/apps/xorg/10-*.conf /usr/share/X11/xorg.conf.d
+
 if [ -f $SRC_DIR/apps/alsa/${BOARD_name}.state ]; then
 	cp $SRC_DIR/apps/alsa/${BOARD_name}.state /var/lib/alsa/asound.state
 fi


### PR DESCRIPTION
the oneshot.sh almost worked as is on minimum image such as DietPi, which doesn't have xorg installed by default. This pull request will handle this case by create the directory first and copy the 10-*.conf files to the image regardless if the dir /usr/share/X11/xorg.conf.d exist or not, as it's required to get xorg running on le potato.